### PR TITLE
:fix color parameter was integer instead of floatting

### DIFF
--- a/src/core/mesh.h
+++ b/src/core/mesh.h
@@ -8,6 +8,7 @@ struct MeshTraits : public OpenMesh::DefaultTraits
 {
     // use floating point
     typedef OpenMesh::Vec3f Point;
+    typedef OpenMesh::Vec3f Color;
 
     // use vertex normals and vertex colors
     VertexAttributes( OpenMesh::Attributes::Normal | OpenMesh::Attributes::Color );


### PR DESCRIPTION
When creating the meshtraits, I forgot to tell openmesh which type we wanted for colors