### PR TITLE
Initialize matrix to identity

### DIFF
--- a/src/gui/modelvisu.cpp
+++ b/src/gui/modelvisu.cpp
@@ -26,10 +26,10 @@ ModelVisu::ModelVisu( QWidget *parent )
     create();
 
 
-    objTransform_   = glm::rotate( objTransform_, glm::radians( 90.f ), glm::vec3( 1, 0, 0 ) );
+    objTransform_   = glm::rotate( glm::mat4{1.f}, glm::radians( 90.f ), glm::vec3( 1, 0, 0 ) );
     eulerTransform_ = glm::eulerAngleXYZ( yaw_, pitch_, roll_ );
 
-    scaleTransform_ = glm::scale( glm::mat4{}, glm::vec3{scale_, scale_, scale_} );
+    scaleTransform_ = glm::scale( glm::mat4{1.f}, glm::vec3{scale_, scale_, scale_} );
 }
 
 

--- a/src/gui/modelvisu.h
+++ b/src/gui/modelvisu.h
@@ -64,11 +64,11 @@ private:
 
     S3DE::Shader simpleShader_;
 
-    glm::mat4 objTransform_;
+    glm::mat4 objTransform_{1.f};
 
-    glm::mat4 eulerTransform_;
+    glm::mat4 eulerTransform_{1.f};
 
-    glm::mat4 scaleTransform_;
+    glm::mat4 scaleTransform_{1.f};
 
     glm::mat4 projection_;
     glm::mat4 modelview_;


### PR DESCRIPTION
Initialize matrix to identity: depending on the version of glm, the default constructor of `glm::mat4` may do the initialization at identity.